### PR TITLE
Bugfix: Handle captions on things that aren't figures

### DIFF
--- a/src/rinoh/frontend/sphinx/__init__.py
+++ b/src/rinoh/frontend/sphinx/__init__.py
@@ -222,7 +222,7 @@ class RinohBuilder(Builder):
 
     def write_doc(self, docname, doctree, docnames, targetname):
         config = self.config
-        suffix, = config.source_suffix
+        suffix, = config.source_suffix[0:1]
         source_path = os.path.join(self.srcdir, docname + suffix)
         parser = ReStructuredTextReader()
         rinoh_tree = parser.from_doctree(source_path, doctree)

--- a/src/rinoh/image.py
+++ b/src/rinoh/image.py
@@ -294,12 +294,19 @@ class Caption(NumberedParagraph):
     @property
     def referenceable(self):
         return self.parent
+      
+    @property
+    def category(self):
+        try:
+            return self.referenceable.category
+        except AttributeError:
+            return "Other"
 
     def prepare(self, flowable_target):
         super().prepare(flowable_target)
         document = flowable_target.document
         get_style = partial(self.get_style, flowable_target=flowable_target)
-        category = self.referenceable.category
+        category = self.category
         numbering_level = get_style('numbering_level')
         section = self.section
         while section and section.level > numbering_level:
@@ -321,7 +328,7 @@ class Caption(NumberedParagraph):
             # document.set_reference(id, ReferenceType.TITLE, caption text)
 
     def text(self, container):
-        label = self.referenceable.category + ' ' + self.number(container)
+        label = self.category + ' ' + self.number(container)
         return MixedStyledText(label + self.content, parent=self)
 
 


### PR DESCRIPTION
Fixes a bug where captions on `literalinclude` blocks threw an exception.